### PR TITLE
only add hunter level once

### DIFF
--- a/src/psrd/stat_block/spell.py
+++ b/src/psrd/stat_block/spell.py
@@ -177,6 +177,8 @@ def parse_level(spell, value):
 					hunterlevels['level'] = l
 		else:
 			finallevels.append({'class': c, 'level': l})
-		if hunterlevels:
-			finallevels.append(hunterlevels)
+
+	if hunterlevels:
+		finallevels.append(hunterlevels)
+
 	spell['level'] = finallevels


### PR DESCRIPTION
This fixes an issue where the hunter level would be added in every
iteration of the loop after seeing a druid or hunter level

This should fix devonjones/PSRD-Data#1