### PR TITLE
source with ./ prefix so that bash finds dir.conf

### DIFF
--- a/src/run_all.sh
+++ b/src/run_all.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-source dir.conf
+source ./dir.conf
 mkdir -p $DATA_DIR
 rm -rf $DATA_DIR/*
 

--- a/src/run_classes.sh
+++ b/src/run_classes.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-source dir.conf
+source ./dir.conf
 ./class_parse.py -o $DATA_DIR -c core     -b "Core Rulebook"           $WEB_DIR/pathfinderRPG/prd/classes/*.html
 ./class_parse.py -o $DATA_DIR -c prestige -b "Core Rulebook"           $WEB_DIR/pathfinderRPG/prd/prestigeClasses/*.html
 ./class_parse.py -o $DATA_DIR -c npc      -b "Core Rulebook"           $WEB_DIR/pathfinderRPG/prd/nPCClasses.html

--- a/src/run_creatures.sh
+++ b/src/run_creatures.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-source dir.conf
+source ./dir.conf
 ./creature_parse.py -o $DATA_DIR -b "Ultimate Magic"  $WEB_DIR/pathfinderRPG/prd/ultimateMagic/magic/newFamiliars.html
 
 ./creature_parse.py -o $DATA_DIR -b "Bestiary" $WEB_DIR/pathfinderRPG/prd/monsters/aasimar.html

--- a/src/run_dump.sh
+++ b/src/run_dump.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-source dir.conf
+source ./dir.conf
 
 rm -rf $DUMP_DIR/*
 

--- a/src/run_extensions.sh
+++ b/src/run_extensions.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-source dir.conf
+source ./dir.conf
 ./item_table_dump.py -o $DATA_DIR -d $DATA_DIR/book-cr.db -b "Core Rulebook" 
 ./extension_loader.py -d ../../pfsrd-data/book-cr.db ../../pfsrd-data/core_rulebook/extensions/items.json
 

--- a/src/run_feats.sh
+++ b/src/run_feats.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-source dir.conf
+source ./dir.conf
 ./feat_parse.py -o $DATA_DIR -b "Core Rulebook"           $WEB_DIR/pathfinderRPG/prd/feats.html
 ./feat_parse.py -o $DATA_DIR -b "Bestiary"                $WEB_DIR/pathfinderRPG/prd/monsters/monsterFeats.html
 #./feat_parse.py -o $DATA_DIR -b "Bestiary 2"              $WEB_DIR/pathfinderRPG/prd/additionalMonsters/monsterFeats.html

--- a/src/run_races.sh
+++ b/src/run_races.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-source dir.conf
+source ./dir.conf
 ./race_parse.py -o $DATA_DIR -b "Core Rulebook" $WEB_DIR/pathfinderRPG/prd/races.html 
 
 ./arg_race_parse.py -o $DATA_DIR -b "Advanced Race Guide" -t "core"     $WEB_DIR/pathfinderRPG/prd/advancedRaceGuide/coreRaces/*.html

--- a/src/run_rules.sh
+++ b/src/run_rules.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-source dir.conf
+source ./dir.conf
 
 # OGL
 ./rules_parse.py -o $DATA_DIR -b "OGL" -t "OGL" $WEB_DIR/pathfinderRPG/prd/openGameLicense.html 

--- a/src/run_skills.sh
+++ b/src/run_skills.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
 
-source dir.conf
+source ./dir.conf
 ./skill_parse.py -o $DATA_DIR -b "Core Rulebook" $WEB_DIR/pathfinderRPG/prd/skills/*.html
 

--- a/src/run_spell_lists.sh
+++ b/src/run_spell_lists.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-source dir.conf
+source ./dir.conf
 ./spell_list_parse.py -o $DATA_DIR -b "Core Rulebook"           $WEB_DIR/pathfinderRPG/prd/spellLists.html
 ./spell_list_parse.py -o $DATA_DIR -b "Advanced Class Guide"    $WEB_DIR/pathfinderRPG/prd/advancedClassGuide/spellLists.html
 ./spell_list_parse.py -o $DATA_DIR -b "Advanced Player's Guide" $WEB_DIR/pathfinderRPG/prd/advanced/advancedSpellLists.html

--- a/src/run_spells.sh
+++ b/src/run_spells.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-source dir.conf
+source ./dir.conf
 ./spell_parse.py -o $DATA_DIR -b "Core Rulebook"           $WEB_DIR/pathfinderRPG/prd/spells/*.html
 ./spell_parse.py -o $DATA_DIR -b "Advanced Class Guide"    $WEB_DIR/pathfinderRPG/prd/advancedClassGuide/spells/*.html
 ./spell_parse.py -o $DATA_DIR -b "Advanced Player's Guide" $WEB_DIR/pathfinderRPG/prd/advanced/spells/*.html


### PR DESCRIPTION
Not a bash expert but this is required on my Fedora. "man source" prints:
If filename does not contain  a slash,  filenames  in PATH are used to find the directory containing filename

By the way, I tried playing with this parser and had this kind of issues https://github.com/devonjones/PSRD-Parser/issues/10. Thanks for the info posted there.
Staying with PSRD-Data for now, which is cool.
